### PR TITLE
Bugfix(css):add dark theme CSS overrides for text and background for Astro Docs

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -12,6 +12,13 @@
   --ondark: #111;
 }
 
+/* Astro Docs Dark Theme Overrides*/
+:root[data-theme='dark'] {
+  --background:  #17181c;
+  --text: #c1c3c8;
+}
+
+
 body {
   color: var(--text);
   background: var(--background);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://schroedinger-hat.org/page/code-of-conduct
-->

### 🔗 Linked issue

Fixes #17 #16 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Root CSS was overriding Astro Starlight Schema - added darkmode specific CSS to counteract.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.