### PR TITLE
(BUGFIX: global.css) unsuppressed list bullets/numbers in Starlight theme

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -19,6 +19,26 @@
 }
 
 
+/* Force lists to show bullets/numbers in Starlight */
+.sl-markdown-content ul {
+  list-style-type: disc !important;
+  padding-left: 1.5rem !important;
+}
+
+.sl-markdown-content ol {
+  list-style-type: decimal !important;
+  padding-left: 1.5rem !important;
+}
+
+.sl-markdown-content ul ul {
+  list-style-type: circle !important;
+}
+
+.sl-markdown-content ol ol {
+  list-style-type: lower-alpha !important;
+}
+
+
 body {
   color: var(--text);
   background: var(--background);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://schroedinger-hat.org/page/code-of-conduct
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Existing CSS theme suppresses list bullets & numbers. Introduced CSS for Starlight them elements specifically to make them visible in documentation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.